### PR TITLE
Add support for delimited identifiers in db, schema, table and column names

### DIFF
--- a/macros/insert_query.sql
+++ b/macros/insert_query.sql
@@ -12,16 +12,16 @@
         , '{{ chunk_column[1] }}'                           AS data_type
 
         , CAST(COUNT(*) AS NUMERIC)  	                                                                                                                                                         AS row_count
-        , SUM(CASE WHEN (CASE WHEN {{ chunk_column[0] }}::VARCHAR = '' THEN NULL ELSE {{ chunk_column[0] }} END ) IS NULL THEN 0 ELSE 1 END)                                                     AS not_null_count
-        , ROUND(((SUM(CASE WHEN (CASE WHEN {{ chunk_column[0] }}::VARCHAR = '' THEN NULL ELSE {{ chunk_column[0] }} END ) IS NULL THEN 0 ELSE 1 END)) / CAST(COUNT(*) AS NUMERIC)) * 100, 2)     AS not_null_percentage
+        , SUM(CASE WHEN (CASE WHEN {{ adapter.quote(chunk_column[0]) }}::VARCHAR = '' THEN NULL ELSE {{ adapter.quote(chunk_column[0]) }} END ) IS NULL THEN 0 ELSE 1 END)                                                     AS not_null_count
+        , ROUND(((SUM(CASE WHEN (CASE WHEN {{ adapter.quote(chunk_column[0]) }}::VARCHAR = '' THEN NULL ELSE {{ adapter.quote(chunk_column[0]) }} END ) IS NULL THEN 0 ELSE 1 END)) / CAST(COUNT(*) AS NUMERIC)) * 100, 2)     AS not_null_percentage
 
-        , SUM(CASE WHEN (CASE WHEN {{ chunk_column[0] }}::VARCHAR = '' THEN NULL ELSE {{ chunk_column[0] }} END ) IS NULL THEN 1 ELSE 0 END)                                                     AS null_count
-        , ROUND(((SUM(CASE WHEN (CASE WHEN {{ chunk_column[0] }}::VARCHAR = '' THEN NULL ELSE {{ chunk_column[0] }} END ) IS NULL THEN 1 ELSE 0 END)) / CAST(COUNT(*) AS NUMERIC)) * 100, 2)     AS null_percentage
+        , SUM(CASE WHEN (CASE WHEN {{ adapter.quote(chunk_column[0]) }}::VARCHAR = '' THEN NULL ELSE {{ adapter.quote(chunk_column[0]) }} END ) IS NULL THEN 1 ELSE 0 END)                                                     AS null_count
+        , ROUND(((SUM(CASE WHEN (CASE WHEN {{ adapter.quote(chunk_column[0]) }}::VARCHAR = '' THEN NULL ELSE {{ adapter.quote(chunk_column[0]) }} END ) IS NULL THEN 1 ELSE 0 END)) / CAST(COUNT(*) AS NUMERIC)) * 100, 2)     AS null_percentage
 
-        , COUNT(DISTINCT {{ chunk_column[0] }})	                                                                                                                                                 AS distinct_count
-        , ROUND(COUNT(DISTINCT {{ chunk_column[0] }})/CAST(COUNT(*) AS NUMERIC) * 100, 2)                                                                                                        AS distinct_count_percentage
+        , COUNT(DISTINCT {{ adapter.quote(chunk_column[0]) }})	                                                                                                                                                 AS distinct_count
+        , ROUND(COUNT(DISTINCT {{ adapter.quote(chunk_column[0]) }})/CAST(COUNT(*) AS NUMERIC) * 100, 2)                                                                                                        AS distinct_count_percentage
 
-        , COUNT(DISTINCT {{ chunk_column[0] }}) = CAST(COUNT(*) AS NUMERIC)                                                                                                                      AS IS_UNIQUE
+        , COUNT(DISTINCT {{ adapter.quote(chunk_column[0]) }}) = CAST(COUNT(*) AS NUMERIC)                                                                                                                      AS IS_UNIQUE
         
         , {% if data_profiler.is_numeric_dtype((chunk_column[1]).lower()) or data_profiler.is_date_or_time_dtype((chunk_column[1]).lower()) %}
             CAST(MIN({{ adapter.quote(chunk_column[0]) }}) AS VARCHAR)

--- a/macros/profiling.sql
+++ b/macros/profiling.sql
@@ -46,7 +46,7 @@
 
         {% for information_schema_data in information_schema_datas %}
 
-            {% set source_table_name = information_schema_data[0] + '.' + information_schema_data[1] + '.' + information_schema_data[2] %}
+            {% set source_table_name = adapter.quote(information_schema_data[0]) + '.' + adapter.quote(information_schema_data[1]) + '.' + adapter.quote(information_schema_data[2]) %}
             {% set column_query %}
 
                 SELECT


### PR DESCRIPTION
While using the data_profiler with one of the data sources we have, we encountered that the package will fail to run if there are identifiers that matches with keywords in Snowflake. In our case we had a table with `group` as a name, columns named as `from` and `date`. 

For our use case we forked the package and apply `adapter.quote` on places where Snowflake keywords could appear. But we were wondering if this change could be useful for other people, so opening a PR with the change.

Thanks for this brilliant package! 🙏 